### PR TITLE
Change the import line to the raw Readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ and change it, as you wish.
     {{1}}
 1. Load the macros via
 
-   `import: https://github.com/liaTemplates/mec2/README.md`
+   `import: https://raw.githubusercontent.com/LiaTemplates/mec2/main/README.md`
 
 2. Copy the definitions into your Project
 


### PR DESCRIPTION
If using the normal link to the README.md file the LiaScript which is importing the template won't get rendered and no real error message is displayed (might be another problem too - but not with the template here). I figured it out just by looking at other template sheets.